### PR TITLE
Fix for IOG tariff going stale and Zappi logging

### DIFF
--- a/apps/pv_opt/pv_opt.py
+++ b/apps/pv_opt/pv_opt.py
@@ -812,7 +812,6 @@ class PVOpt(hass.Hass):
                                         export=(imp_exp == "export"),
                                         host=self,
                                     )
-                                    self.log(tariffs)
                                     self.bottlecap_entities[imp_exp] = entity
                                     if "AGILE" in tariff_code:
                                         self.agile = True          # Tariff is Octopus Agile
@@ -2617,7 +2616,8 @@ class PVOpt(hass.Hass):
                     ],
                     axis=1,
                 ).set_axis(["bottlecap", "pv_opt"], axis=1)
-
+                # self.log (df)
+                
                 # Drop any Savings Sessions
 
                 for id in self.saving_events:

--- a/apps/pv_opt/pv_opt.py
+++ b/apps/pv_opt/pv_opt.py
@@ -812,6 +812,7 @@ class PVOpt(hass.Hass):
                                         export=(imp_exp == "export"),
                                         host=self,
                                     )
+                                    self.log(tariffs)
                                     self.bottlecap_entities[imp_exp] = entity
                                     if "AGILE" in tariff_code:
                                         self.agile = True          # Tariff is Octopus Agile
@@ -2029,11 +2030,7 @@ class PVOpt(hass.Hass):
                 )
 
             self.charge_power = self.windows["forced"].iloc[0]
-            voltage = self.get_config("battery_voltage", default=50)
-            if voltage > 0:
-                self.charge_current = self.charge_power / voltage
-            else:
-                self.charge_current = None
+            self.charge_current = self.charge_power / self.get_config("battery_voltage", default=50)
             self.charge_start_datetime = self.windows["start"].iloc[0].tz_convert(self.tz)
             self.charge_end_datetime = self.windows["end"].iloc[0].tz_convert(self.tz)
             self.charge_target_soc = self.windows["soc_end"].iloc[0]
@@ -2196,17 +2193,16 @@ class PVOpt(hass.Hass):
             },
         )
 
-        if self.charge_current is not None:
-            self.write_to_hass(
-                entity=f"sensor.{self.prefix}_charge_current",
-                state=round(self.charge_current, 2),
-                attributes={
-                    "friendly_name": "PV Opt Charging Current",
-                    "unit_of_measurement": "A",
-                    "state_class": "measurement",
-                    "device_class": "current",
-                },
-            )
+        self.write_to_hass(
+            entity=f"sensor.{self.prefix}_charge_current",
+            state=round(self.charge_current, 2),
+            attributes={
+                "friendly_name": "PV Opt Charging Current",
+                "unit_of_measurement": "A",
+                "state_class": "measurement",
+                "device_class": "current",
+            },
+        )
 
         for offset in [1, 4, 8, 12]:
             loc = pd.Timestamp.now(tz="UTC") + pd.Timedelta(offset, "hours")
@@ -2621,8 +2617,7 @@ class PVOpt(hass.Hass):
                     ],
                     axis=1,
                 ).set_axis(["bottlecap", "pv_opt"], axis=1)
-                # self.log (df)
-                
+
                 # Drop any Savings Sessions
 
                 for id in self.saving_events:

--- a/apps/pv_opt/pv_opt.py
+++ b/apps/pv_opt/pv_opt.py
@@ -563,7 +563,7 @@ class PVOpt(hass.Hass):
         self.log("")
         self.io_dispatch_attrib = self.get_state(self.io_entity, attribute="all")
         for k in [x for x in self.io_dispatch_attrib.keys() if "dispatches" not in x]:
-            self.log(f" {k:20s} {self.io_dispatch_attrib[k]}")
+            self.rlog(f" {k:20s} {self.io_dispatch_attrib[k]}")
 
         for k in [x for x in self.io_dispatch_attrib.keys() if "dispatches" in x]:
             self.log(f"  {k:20s} {'Start':20s} {'End':20s} {'Charge':12s} {'Source':12s}")
@@ -2677,8 +2677,8 @@ class PVOpt(hass.Hass):
 
     def hass2df(self, entity_id, days=2, log=False, freq=None):
         if log:
-            self.log(f">>> Getting {days} days' history for {entity_id}")
-            self.log(f">>> Entity exits: {self.entity_exists(entity_id)}")
+            self.rlog(f">>> Getting {days} days' history for {entity_id}")
+            self.log(f">>> Entity exists: {self.entity_exists(entity_id)}")
 
         hist = None
 

--- a/apps/pv_opt/pv_opt.py
+++ b/apps/pv_opt/pv_opt.py
@@ -2654,13 +2654,13 @@ class PVOpt(hass.Hass):
                     ],
                     axis=1,
                 ).set_axis(["bottlecap", "pv_opt"], axis=1)
-                self.log("Now in function check_tariffs_vs_bottlecap")
-                self.log("about to log df")
-                self.log(".............................")
-                self.log(df)
-                self.log("about to log df as a string")
-                self.log(".............................")
-                self.log(f">>>\n{df.to_string()}")
+                # self.log("Now in function check_tariffs_vs_bottlecap")
+                # self.log("about to log df")
+                # self.log(".............................")
+                # self.log(df)
+                # self.log("about to log df as a string")
+                # self.log(".............................")
+                # self.log(f">>>\n{df.to_string()}")
        
 
                 # Drop any Savings Sessions
@@ -2683,7 +2683,7 @@ class PVOpt(hass.Hass):
 
             self.log(f"  {direction.title()}: {str_log}")
             # SVB added
-            self.rlog(self.contract.tariffs[direction].to_df(start=df.index[0], end=df.index[-1], day_ahead=False))
+            # self.rlog(self.contract.tariffs[direction].to_df(start=df.index[0], end=df.index[-1], day_ahead=False))
             #if err:
             #    self.rlog(self.contract.tariffs[direction].to_df(start=df.index[0], end=df.index[-1], day_ahead=False))
 

--- a/apps/pv_opt/pv_opt.py
+++ b/apps/pv_opt/pv_opt.py
@@ -100,6 +100,7 @@ DEFAULT_CONFIG = {
     "forced_discharge": {"default": True, "domain": "switch"},
     "allow_cyclic": {"default": False, "domain": "switch"},
     "use_solar": {"default": True, "domain": "switch"},
+    "ev_part_of_house_load": {"default": True, "domain": "switch"},
     "optimise_frequency_minutes": {
         "default": 10,
         "attributes": {
@@ -824,6 +825,8 @@ class PVOpt(hass.Hass):
                         exp=tariffs["export"],
                         host=self,
                     )
+                    self.log("Contract =")
+                    self.log(self.contract)
                     self.log("")
                     self.rlog("Contract tariffs loaded OK")
 
@@ -2352,6 +2355,8 @@ class PVOpt(hass.Hass):
                     days=days,
                     log=self.debug,
                 )
+                self.log("Df after first load is:......")
+                self.log(df.to_string())
 
             if df is None:
                 self._status("ERROR: No consumption history.")
@@ -2393,8 +2398,35 @@ class PVOpt(hass.Hass):
             if (start < time_now) and (end < time_now):
                 consumption["consumption"] = df.loc[start:end]
             else:
+                df_EV = None                                       # To store EV consumption
+                df_EV_Total = None                                 # To store EV consumption and Total consumption
+                dfx = None
+
+                if self.get_config("ev_part_of_house_load", True):
+                    self.log ("EV charger is seen as house load, so subtracting EV charging from Total consumption")
+                    df_EV_Total = pd.concat([ev_power, df], axis = 1)  # concatenate total consumption and ev consumption into a single dataframe (as they are different lengths)
+                    df_EV_Total.columns = ['EV', 'Total']              # Set column names
+                    df_EV_Total = df_EV_Total.fillna(0)                # fill any missing values with 0
+                
+                    #self.log("Attempt to concatenate is")
+                    #self.log(df_EV_Total)
+                    #self.log("Attempt to concatenate is")
+                    #self.log(df_EV_Total.to_string())
+
+                    df_EV = df_EV_Total["EV"].squeeze()                #Extract EV consumption to Series
+                    df_Total = df_EV_Total["Total"].squeeze()          #Extract total consumption to Series
+                    df = df_Total - df_EV                              #Substract EV consumption from Total Consumption
+                
+                    self.log("Result of subtraction is")
+                    self.log(df.to_string())
+
+                #Add consumption margin
                 df = df * (1 + self.get_config("consumption_margin") / 100)
+                self.log("Df after adding consumption margin is.......")
+                self.log(df.to_string())
+
                 dfx = pd.Series(index=df.index, data=df.to_list())
+
                 # Group by time and take the mean
                 df = df.groupby(df.index.time).aggregate(self.get_config("consumption_grouping"))
                 df.name = "consumption"
@@ -2457,6 +2489,8 @@ class PVOpt(hass.Hass):
             self.log("  - Consumption estimated OK")
 
         self.log(f"  - Total consumption: {(consumption['consumption'].sum() / 2000):0.1f} kWh")
+        self.log("Printing final result of routine load_consumption.....")
+        self.log(consumption.to_string())
         return consumption
 
     def _compare_tariffs(self):
@@ -2620,8 +2654,15 @@ class PVOpt(hass.Hass):
                     ],
                     axis=1,
                 ).set_axis(["bottlecap", "pv_opt"], axis=1)
-                # self.log(df)
-                
+                self.log("Now in function check_tariffs_vs_bottlecap")
+                self.log("about to log df")
+                self.log(".............................")
+                self.log(df)
+                self.log("about to log df as a string")
+                self.log(".............................")
+                self.log(f">>>\n{df.to_string()}")
+       
+
                 # Drop any Savings Sessions
 
                 for id in self.saving_events:
@@ -2641,8 +2682,10 @@ class PVOpt(hass.Hass):
                     err = True
 
             self.log(f"  {direction.title()}: {str_log}")
-            if err:
-                self.rlog(self.contract.tariffs[direction].to_df(start=df.index[0], end=df.index[-1], day_ahead=False))
+            # SVB added
+            self.rlog(self.contract.tariffs[direction].to_df(start=df.index[0], end=df.index[-1], day_ahead=False))
+            #if err:
+            #    self.rlog(self.contract.tariffs[direction].to_df(start=df.index[0], end=df.index[-1], day_ahead=False))
 
     def ulog(self, strlog, underline="-", words=False):
         self.log("")


### PR DESCRIPTION
When the IOG tariff is loaded at midnight UTC (1am BST) it loads 27 hours of data, so through to the next day at 04:30. After that, the df (which is reset to cover 48 hours at midnight BST) is still filled with the cheap rate for data beyond the 27 hours. Once we roll all the way from the 1am load to the time it really counts, which is just before 23:20, we don't have an expensive rate on file, so no charging occurs.

This PR creates a separate contract load for IOG., set to 4.40pm daily. This does not include the same checks that Agile has for when the tariff expires, because it doesn't load sufficient data to get it through to that point. The time at least ensures that an expensive rate is on file when the plan just before cheap rate makes the final charging decision. A later time may be more beneficial, this is under investigation. 

The Zappi historic consumption logging was creating an empty dataframe due to an extra +, removing this now logs data which on first glance now looks correct. 