### PR TITLE
Fix: #249 - Limit Discharging to battery_current_limit_amps

### DIFF
--- a/apps/pv_opt/config/config.yaml
+++ b/apps/pv_opt/config/config.yaml
@@ -3,8 +3,8 @@ pvpy:
   module: pvpy
   global: true
 
-solis_cloud:
-  module: solis_cloud
+solis:
+  module: solis
   global: true
 
 inverters:
@@ -16,7 +16,7 @@ pv_opt:
   class: PVOpt
   dependencies:
     - pvpy
-    - solis_cloud
+    - solis
 
   log: pv_opt_log
   prefix: pvopt
@@ -131,10 +131,10 @@ pv_opt:
   # update_cycle_seconds: 15
   # maximum_dod_percent: number.{device_name}_battery_minimum_soc 
   
-  # id_consumption_today: sensor.{device_name}_consumption_today
-  # id_consumption:
-  #   - sensor.{device_name}_house_load
-  #   - sensor.{device_name}_bypass_load
+  id_consumption_today: sensor.{device_name}_consumption_today
+  id_consumption:
+    - sensor.{device_name}_house_load
+    - sensor.{device_name}_bypass_load
 
   # id_grid_import_today: sensor.{device_name}_grid_import_today
   # id_grid_export_today: sensor.{device_name}_grid_export_today
@@ -225,26 +225,6 @@ pv_opt:
   # id_timed_discharge_current: sensor.{device_name}_timed_discharge_current
 
   # id_inverter_mode: sensor.{device_name}_storage_control_mode
-
-  # ===============================================================================================================
-  # Brand / Integration Specific Config: SOLIS_SOLIS_CLOUD: https://github.com/hultenvp/solis-sensor & https://github.com/stevegal/solis_control
-  # ===============================================================================================================
-  #
-  # These are the default entities used with the Solis Solis Cloud integration. You can change them here and over-ride the defaults
-
-  # inverter_type: SOLIS_SOLIS_CLOUD
-  # device_name: solis
-  
-  # battery_voltage: sensor.{device_name}_battery_voltage
-  # update_cycle_seconds: 300
-  # maximum_dod_percent: number.{device_name}_battery_minimum_soc 
-  
-  id_consumption_today: sensor.{device_name}_energy_today
-
-  id_grid_import_today: sensor.{device_name}_daily_grid_energy_purchased
-  id_grid_export_today: sensor.{device_name}_daily_on_grid_energy
-
-  id_battery_soc: sensor.{device_name}_remaining_battery_capacity
 
   # ===============================================================================================================
   # Brand / Integration Specific Config: SUNSYNK_SOLARSYNK2: 

--- a/apps/pv_opt/config/config.yaml
+++ b/apps/pv_opt/config/config.yaml
@@ -3,8 +3,8 @@ pvpy:
   module: pvpy
   global: true
 
-solis:
-  module: solis
+solis_cloud:
+  module: solis_cloud
   global: true
 
 inverters:
@@ -16,7 +16,7 @@ pv_opt:
   class: PVOpt
   dependencies:
     - pvpy
-    - solis
+    - solis_cloud
 
   log: pv_opt_log
   prefix: pvopt
@@ -131,10 +131,10 @@ pv_opt:
   # update_cycle_seconds: 15
   # maximum_dod_percent: number.{device_name}_battery_minimum_soc 
   
-  id_consumption_today: sensor.{device_name}_consumption_today
-  id_consumption:
-    - sensor.{device_name}_house_load
-    - sensor.{device_name}_bypass_load
+  # id_consumption_today: sensor.{device_name}_consumption_today
+  # id_consumption:
+  #   - sensor.{device_name}_house_load
+  #   - sensor.{device_name}_bypass_load
 
   # id_grid_import_today: sensor.{device_name}_grid_import_today
   # id_grid_export_today: sensor.{device_name}_grid_export_today
@@ -225,6 +225,26 @@ pv_opt:
   # id_timed_discharge_current: sensor.{device_name}_timed_discharge_current
 
   # id_inverter_mode: sensor.{device_name}_storage_control_mode
+
+  # ===============================================================================================================
+  # Brand / Integration Specific Config: SOLIS_SOLIS_CLOUD: https://github.com/hultenvp/solis-sensor & https://github.com/stevegal/solis_control
+  # ===============================================================================================================
+  #
+  # These are the default entities used with the Solis Solis Cloud integration. You can change them here and over-ride the defaults
+
+  # inverter_type: SOLIS_SOLIS_CLOUD
+  # device_name: solis
+  
+  # battery_voltage: sensor.{device_name}_battery_voltage
+  # update_cycle_seconds: 300
+  # maximum_dod_percent: number.{device_name}_battery_minimum_soc 
+  
+  id_consumption_today: sensor.{device_name}_energy_today
+
+  id_grid_import_today: sensor.{device_name}_daily_grid_energy_purchased
+  id_grid_export_today: sensor.{device_name}_daily_on_grid_energy
+
+  id_battery_soc: sensor.{device_name}_remaining_battery_capacity
 
   # ===============================================================================================================
   # Brand / Integration Specific Config: SUNSYNK_SOLARSYNK2: 

--- a/apps/pv_opt/pv_opt.py
+++ b/apps/pv_opt/pv_opt.py
@@ -717,6 +717,7 @@ class PVOpt(hass.Hass):
         self.battery_model = pv.BatteryModel(
             capacity=self.get_config("battery_capacity_wh"),
             max_dod=self.get_config("maximum_dod_percent") / 100,
+            current_limit_amps=self.get_config("battery_current_limit_amps"),
         )
         self.pv_system = pv.PVsystemModel("PV_Opt", self.inverter_model, self.battery_model, host=self)
 

--- a/apps/pv_opt/pv_opt.py
+++ b/apps/pv_opt/pv_opt.py
@@ -717,7 +717,8 @@ class PVOpt(hass.Hass):
         self.battery_model = pv.BatteryModel(
             capacity=self.get_config("battery_capacity_wh"),
             max_dod=self.get_config("maximum_dod_percent") / 100,
-            current_limit_amps=self.get_config("battery_current_limit_amps"),
+            current_limit_amps=self.get_config("battery_current_limit_amps", default=100),
+            voltage=self.get_config("battery_voltage", default=50),
         )
         self.pv_system = pv.PVsystemModel("PV_Opt", self.inverter_model, self.battery_model, host=self)
 

--- a/apps/pv_opt/pvpy.py
+++ b/apps/pv_opt/pvpy.py
@@ -390,12 +390,12 @@ class BatteryModel:
         pass
     
     @property
-    def max_charge_power(self):
+    def max_charge_power(self) -> int:
         """ returns the maximum watts at which the battery can charge. """
         return self.current_limit_amps * self.__voltage # probably shouldn't use magic numbers here.
     
     @property
-    def max_discharge_power(self):
+    def max_discharge_power(self) -> int:
         """ returns the maximum watts at which the battery can discharge. """
         return self.max_charge_power
 

--- a/apps/pv_opt/pvpy.py
+++ b/apps/pv_opt/pvpy.py
@@ -374,17 +374,17 @@ class BatteryModel:
     """Describes the battery system attached to the inverter
 
     Attributes:
-        __voltage: An int describing the voltage of the battery system.
         capacity: An integer describing the Wh capacity of the battery.
         max_dod: A float describing the maximum depth of discharge of the battery.
         current_limit_amps: An int describing the maximum amps at which the battery can charge/discharge.
+        voltage: An int describing the voltage of the battery system.
     """
 
-    def __init__(self, capacity: int, max_dod: float = 0.15, current_limit_amps: int = 100) -> None:
+    def __init__(self, capacity: int, max_dod: float = 0.15, current_limit_amps: int = 100, voltage: int = 50) -> None:
         self.capacity = capacity
         self.max_dod = max_dod
         self.current_limit_amps = current_limit_amps
-        self.__voltage : int = 48
+        self.voltage = voltage
 
     def __str__(self):
         pass
@@ -392,7 +392,7 @@ class BatteryModel:
     @property
     def max_charge_power(self) -> int:
         """ returns the maximum watts at which the battery can charge. """
-        return self.current_limit_amps * self.__voltage # probably shouldn't use magic numbers here.
+        return self.current_limit_amps * self.voltage
     
     @property
     def max_discharge_power(self) -> int:


### PR DESCRIPTION
Fixes #249.  The issue was that in the charge window it was correctly using `inverter.charger_power` to calculate max charge, but in the discharge window it was using `inverter.inverter_power`.  The quickest fix would be to just use `inverter.charger_power` in the discharge window calculation (and I've confirmed that this works as expected).  

I thought it might be cleaner though to have the BatteryModel understand the properties of the battery.  And since we're talking about charging/discharging the battery - to switch over to use that.  Therefore I passed along the `battery_current_limit_amps` config into the `BatteryModel` class and calculate the max charge and discharge rates in watts as read-only properties.

I think the only awkward thing here is that we specify the battery limit in amps, but calculate charge/discharge power in watts... so there's a few back and forths.  It does make sense though as most battery specs specify their charge/discharge units in Amps.

Screenshots:
I've set the `battery_current_limit_amps` to 37 and you can see that now it's limited (it does go to 38 in the display, but that's a rounding issue):
![image](https://github.com/fboundy/pv_opt/assets/125502786/a4102c46-cf42-48eb-8218-3af7d4c28d9b)

Whereas the original code produces this:
![image](https://github.com/fboundy/pv_opt/assets/125502786/d4569c13-1f0f-47b7-a646-c8eb9a8f56d0)

# Question to @fboundy 
I'm assuming 48v batteries in order to convert the `BatteryModel.current_limit_amps` into Watts.  I'm not sure this is a great assumption.  Should I read this from a sensor?  Or create a config value for it?