### PR TITLE
#418, bugfix for savings events and electricity events

### DIFF
--- a/apps/pv_opt/pv_opt.py
+++ b/apps/pv_opt/pv_opt.py
@@ -13,7 +13,7 @@ import pandas as pd
 import pvpy as pv
 from numpy import nan
 
-VERSION = "5.0.2"
+VERSION = "5.0.3"
 
 UNITS = {
     "current": "A",
@@ -1693,8 +1693,10 @@ class PVOpt(hass.Hass):
                 # SVB debugging line to force export tariff
                 # self.contract.tariffs["export"] = pv.Tariff("None", export=True, unit=15, octopus=False, host=self)
             self.rlog("")
-            self._load_saving_events()
-            self._load_free_electricity_events()
+            # self._load_saving_events()
+            self._load_saving_events_new()  # Resolves Issue #418.
+            # self._load_free_electricity_events()
+            self._load_free_electricity_events_new()  # Resolves Issue #418
 
         self.log("")
         self.log("Finished loading contract")


### PR DESCRIPTION
Savings Events and Free Electricity sessions were previously converted to use calendar entities, but the def calls in load_contract were missed. Correct this error.