### PR TITLE
IOG tariff - update Pv_opt to handle 6 hour charge cap tariff codes

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# PV Opt: Home Assistant Solar/Battery Optimiser v5.1.3
+# PV Opt: Home Assistant Solar/Battery Optimiser v5.1.5
 
 <h2>*** Announcment *** </h2>
 

--- a/apps/pv_opt/pv_opt.py
+++ b/apps/pv_opt/pv_opt.py
@@ -21,7 +21,7 @@ import pandas as pd
 import pvpy as pv
 from numpy import nan
 
-VERSION = "5.1.4"
+VERSION = "5.1.5"
 
 UNITS = {
     "current": "A",
@@ -1744,8 +1744,10 @@ class PVOpt(hass.Hass):
 
                 if "AGILE" in tariff.name:
                     self.agile = True
-                if "INTELLI" in tariff.name:
+                if "INTELLI" in tariff.name or "IOG" in tariff.name:
                     self.intelligent = True
+                    if not hasattr(self, "io_dispatching_sensor"):
+                        self._get_io_sensors()
 
         if self.agile:
             self.log("  AGILE tariff detected. Rates will update at 16:00 daily")
@@ -2634,10 +2636,14 @@ class PVOpt(hass.Hass):
 
             # reload pricing from bottlecap dave sensors on every optimiser run
 
-            self.log("")
-            self.ulog("Reload IOG prices from Octopus Energy Integration")
+            if self.bottlecap_entities["import"] is not None:
+                self.log("")
+                self.ulog("Reload IOG prices from Octopus Energy Integration")
 
-            self.io_prices = self.get_io_tariffs(self.octopus_import_entity[0])
+                self.io_prices = self.get_io_tariffs(self.bottlecap_entities["import"])
+                
+            elif self.debug and "T" in self.debug_cat:
+                self.log("Skipping IOG price reload - no bottlecap entity available (using manual/fallback tariff)")
 
         elif ((pd.Timestamp.now(tz="UTC") - self.contract_last_loaded).total_seconds() / 3600) > 6:
             # Reload every 6 hours

--- a/apps/pv_opt/pvpy.py
+++ b/apps/pv_opt/pvpy.py
@@ -130,7 +130,7 @@ class Tariff:
                     self.day = [{"value_inc_vat": day, "valid_from": valid_from}]
                     self.night = [{"value_inc_vat": night, "valid_from": valid_from}]
 
-        if "INTELLI" in name and not self.export:
+        if ("INTELLI" in name or "IOG" in name) and not self.export:
             if self.host.get_config("octopus_auto"):
                 try:
                     self.log(f"    Trying to find Octopus Intelligent Entities from Octopus Energy Integration:")
@@ -185,6 +185,10 @@ class Tariff:
                 for x in requests.get(url, params=params).json()["results"]
                 if x["payment_method"] != "NON_DIRECT_DEBIT"
             ]
+            if not self.fixed:
+                raise ValueError(
+                    f"Octopus API returned no standing-charges for tariff '{code}' (product '{product}'). URL: {url}"
+                )
 
         if self.eco7:
             url = f"{OCTOPUS_PRODUCT_URL}{product}/electricity-tariffs/{code}/day-unit-rates/"
@@ -201,6 +205,10 @@ class Tariff:
         else:
             url = f"{OCTOPUS_PRODUCT_URL}{product}/electricity-tariffs/{code}/standard-unit-rates/"
             self.unit = requests.get(url, params=params).json()["results"]
+            if not self.unit:
+                raise ValueError(
+                    f"Octopus API returned no standard-unit-rates for tariff '{code}' (product '{product}'). URL: {url}"
+                )
             # SVB logging
             # self.log("")
             # self.log("Printing self.unit")
@@ -358,7 +366,7 @@ class Tariff:
             # to overwrite the Df with IOG data from the BottlecapDave integration, loaded in pv_opt.py and passed in here via self.host.io_prices.
             # (SVB Note: io_prices should be passed in via Class, but I cannot figure out the structure of Tariff and Contract Classes to do this)
 
-            if len(self.host.io_prices) > 0 and "INTELLI" in self.name:
+            if len(self.host.io_prices) > 0 and ("INTELLI" in self.name or "IOG" in self.name):
                 # Add IO slot prices as a column to dataframe.
                 df = pd.concat([df, self.host.io_prices], axis=1).set_axis(["unit", "io_unit"], axis=1)
 


### PR DESCRIPTION
Implement detection of new tariff code not providing pricing information from Octopus Website. 

Note: this is a partial fix and requires the use of the previous IOG tariff code being added to config.yaml, as follows:

`octopus_import_tariff_code: E-1R-INTELLI-VAR-24-10-29-N`