### PR TITLE
v5.1.6

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# PV Opt: Home Assistant Solar/Battery Optimiser v5.1.5
+# PV Opt: Home Assistant Solar/Battery Optimiser v5.1.6
 
 <h2>*** Announcement *** </h2>
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # PV Opt: Home Assistant Solar/Battery Optimiser v5.1.5
 
-<h2>*** Announcment *** </h2>
+<h2>*** Announcement *** </h2>
 
 Pv_opt is now available as an HomeAssistant App (formely known as an AddOn)
 

--- a/apps/pv_opt/pv_opt.py
+++ b/apps/pv_opt/pv_opt.py
@@ -21,7 +21,7 @@ import pandas as pd
 import pvpy as pv
 from numpy import nan
 
-VERSION = "5.1.6-Beta-3"
+VERSION = "5.1.6-Beta-4"
 
 UNITS = {
     "current": "A",
@@ -1996,7 +1996,7 @@ class PVOpt(hass.Hass):
         """Scan self.args for credential-shaped keys (mqtt_pass, api_token etc.) and
         register their values with rlog()'s redaction list before anything is logged."""
         for item, value in self.args.items():
-            if not self.SENSITIVE_ARG_REGEX.search(item):
+            if not SENSITIVE_ARG_REGEX.search(item):
                 continue
             for v in (value if isinstance(value, list) else [value]):
                 if isinstance(v, str) and v and re.escape(v) not in self.redact_regex:

--- a/apps/pv_opt/pv_opt.py
+++ b/apps/pv_opt/pv_opt.py
@@ -21,7 +21,7 @@ import pandas as pd
 import pvpy as pv
 from numpy import nan
 
-VERSION = "5.1.6-Beta-2"
+VERSION = "5.1.6-Beta-3"
 
 UNITS = {
     "current": "A",
@@ -71,6 +71,8 @@ REDACT_REGEX = [
     r"A-[0-f]{8}",  # Account Number
     r"sk_live_[a-zA-Z0-9]{24}",  # API
 ]
+
+SENSITIVE_ARG_REGEX = re.compile(r"pass|secret|token|api[_-]?key", re.IGNORECASE)
 
 EVENT_TRIGGER = "PV_OPT"
 DEBUG_TRIGGER = "PV_DEBUG"
@@ -1990,7 +1992,19 @@ class PVOpt(hass.Hass):
         else:
             return True
 
+    def _register_sensitive_args(self):
+        """Scan self.args for credential-shaped keys (mqtt_pass, api_token etc.) and
+        register their values with rlog()'s redaction list before anything is logged."""
+        for item, value in self.args.items():
+            if not self.SENSITIVE_ARG_REGEX.search(item):
+                continue
+            for v in (value if isinstance(value, list) else [value]):
+                if isinstance(v, str) and v and re.escape(v) not in self.redact_regex:
+                    self.redact_regex.append(re.escape(v))
+
     def _load_args(self, items=None):
+        self._register_sensitive_args()
+
         if self.debug and "S" in self.debug_cat:
             self.rlog(self.args)
 

--- a/apps/pv_opt/pv_opt.py
+++ b/apps/pv_opt/pv_opt.py
@@ -21,7 +21,7 @@ import pandas as pd
 import pvpy as pv
 from numpy import nan
 
-VERSION = "5.1.5"
+VERSION = "5.1.6-Beta-1"
 
 UNITS = {
     "current": "A",

--- a/apps/pv_opt/pv_opt.py
+++ b/apps/pv_opt/pv_opt.py
@@ -21,7 +21,7 @@ import pandas as pd
 import pvpy as pv
 from numpy import nan
 
-VERSION = "5.1.6-Beta-4"
+VERSION = "5.1.6"
 
 UNITS = {
     "current": "A",

--- a/apps/pv_opt/pv_opt.py
+++ b/apps/pv_opt/pv_opt.py
@@ -1951,21 +1951,17 @@ class PVOpt(hass.Hass):
     def get_ha_value(self, entity_id):
         value = None
 
-        # if the entity doesn't exist return None
         if self.entity_exists(entity_id=entity_id):
             state = self.get_state_retry(entity_id=entity_id)
 
-            # if the state is None return None
             if state is not None:
                 if (state in ["unknown", "unavailable"]) and (entity_id[:6] != "button"):
                     e = f"HA returned {state} for state of {entity_id}"
                     self.status(f"ERROR: {e}")
                     self.log(e, level="ERROR")
-                # if the state is 'on' or 'off' then it's a bool
+                    return None
                 elif state.lower() in ["on", "off", "true", "false"]:
                     value = state.lower() in ["on", "true"]
-
-                # see if we can coerce it into an int 1st and then a floar
                 else:
                     for t in [int, float]:
                         try:
@@ -1973,7 +1969,6 @@ class PVOpt(hass.Hass):
                         except:
                             pass
 
-                # if none of the above return a string
                 if value is None:
                     value = state
 

--- a/apps/pv_opt/pv_opt.py
+++ b/apps/pv_opt/pv_opt.py
@@ -21,7 +21,7 @@ import pandas as pd
 import pvpy as pv
 from numpy import nan
 
-VERSION = "5.1.6-Beta-1"
+VERSION = "5.1.6-Beta-2"
 
 UNITS = {
     "current": "A",

--- a/apps/pv_opt/pvpy.py
+++ b/apps/pv_opt/pvpy.py
@@ -1103,26 +1103,30 @@ class PVsystemModel:
             a = self.flows["forced"][self.flows["forced"] != 0].to_dict()
             new_slots = [(k, a[k]) for k in a]
 
-            revised_slots = []
-            skip_flag = False
-            for i, x in enumerate(zip(new_slots[:-1], new_slots[1:])):
+            if len(new_slots) <= 1:
+                # Nothing to pair against - a single isolated forced slot can't be cyclic
+                revised_slots = list(new_slots)
+            else:
+                revised_slots = []
+                skip_flag = False
+                for i, x in enumerate(zip(new_slots[:-1], new_slots[1:])):
 
-                if (
-                    (int(x[0][1]) == self.inverter.charger_power)
-                    & (int(-x[1][1]) == self.inverter.charger_power)
-                    & (x[1][0] - x[0][0] == pd.Timedelta("30min"))
-                ):
-                    skip_flag = True
-                    if log:
-                        self.log(
-                            f"  Skipping slots at {x[0][0].strftime(TIME_FORMAT)} ({x[0][1]}W) and {x[1][0].strftime(TIME_FORMAT)} ({x[1][1]}W)"
-                        )
-                elif skip_flag:
-                    skip_flag = False
-                else:
-                    revised_slots.append(x[0])
-                    if i == len(new_slots) - 2:
-                        revised_slots.append(x[1])
+                    if (
+                        (int(x[0][1]) == self.inverter.charger_power)
+                        & (int(-x[1][1]) == self.inverter.charger_power)
+                        & (x[1][0] - x[0][0] == pd.Timedelta("30min"))
+                    ):
+                        skip_flag = True
+                        if log:
+                            self.log(
+                                f"  Skipping slots at {x[0][0].strftime(TIME_FORMAT)} ({x[0][1]}W) and {x[1][0].strftime(TIME_FORMAT)} ({x[1][1]}W)"
+                            )
+                    elif skip_flag:
+                        skip_flag = False
+                    else:
+                        revised_slots.append(x[0])
+                        if i == len(new_slots) - 2:
+                            revised_slots.append(x[1])
 
             self.calculate_flows(slots=revised_slots)
 

--- a/apps/pv_opt/sunsynk.py
+++ b/apps/pv_opt/sunsynk.py
@@ -305,7 +305,6 @@ class SolarSynkV3Inverter(SunsynkBaseInverter):
 
         else:
             params = {
-                self._brand_config["json_work_mode"]: 2,
                 self._brand_config["json_timed_charge_target_soc"]: 100,
                 self._brand_config["json_timed_charge_start"]: "00:00",
                 self._brand_config["json_timed_charge_end"]: "00:00",

--- a/apps/pv_opt/sunsynk.py
+++ b/apps/pv_opt/sunsynk.py
@@ -184,9 +184,18 @@ class SunsynkInverterController(ABC):
         raise Exception(e)
 
     def _convert_kwargs(self, kwargs: dict) -> dict:
-        """Convert numpy/pandas types to native Python types."""
+        """Convert numpy/pandas types to native Python types.
+
+        Keys with a value of None are dropped entirely rather than being
+        forwarded as null. Callers use start=None etc. to mean 'leave this
+        field unchanged', but set_solar_settings has a strict schema that
+        rejects null values outright, and the SolarSynkV3 text-helper merge
+        would otherwise serialise the literal string "None".
+        """
         converted = {}
         for key, value in kwargs.items():
+            if value is None:
+                continue
             if isinstance(value, (np.integer, np.int64)):
                 converted[key] = int(value)
             elif isinstance(value, (np.floating, np.float64)):

--- a/apps/pv_opt/sunsynk.py
+++ b/apps/pv_opt/sunsynk.py
@@ -335,7 +335,7 @@ class SolarSynkV3Inverter(SunsynkBaseInverter):
             self._set_inverter(**params)
 
             params = {
-                self._brand_config["json_timed_discharge_power"]: kwargs.get("power", 0),
+                self._brand_config["json_timed_discharge_power"]: abs(kwargs.get("power", 0)),
                 self._brand_config["json_timed_discharge_enable"]: True,
                 self._brand_config["json_gen_discharge_enable"]: False,
             }
@@ -474,7 +474,7 @@ class SolarSunsynkInverter(SunsynkBaseInverter):
                 self._brand_config["json_timed_discharge_end"]: kwargs.get(
                     "end", time_now.ceil("30min").strftime(TIMEFORMAT)
                 ),
-                self._brand_config["json_timed_discharge_power"]: kwargs.get("power", 0),
+                self._brand_config["json_timed_discharge_power"]: abs(kwargs.get("power", 0)),
                 self._brand_config["json_timed_discharge_enable"]: True,
                 self._brand_config["json_gen_discharge_enable"]: False,
             }


### PR DESCRIPTION
Update Pv_opt to 5.1.6
- Bugfix on last commit for redacting MQTT password (stevebuk1/pv_opt_app#47)
- Redact MQTT password (and anything else that looks like a login or key). (Bugfix for stevebuk1/pv_opt_app#47)
- Bugfix for "run_every callback error: unsupported operand type(s) for 'str' and 'int'" error (no issue raised)
- Fix bug in Cyclic removal (if there is a single discharge slot, it is incorrectly tagged as cyclic).
- Sunsynk bugfixes for Selltime3 (https://github.com/stevebuk1/pv_opt/issues/424)
- Sunsynk bugfixes (https://github.com/stevebuk1/pv_opt/issues/424) - ensure Selltime3 is positive. 
- Sunsynk bugfixes (https://github.com/stevebuk1/pv_opt/issues/424) - remove Sysworkmode write from disable charging routine.
- IOG tariff - update Pv_opt to handle 6 hour charge cap tariff codes.
  Note: this is a partial fix and requires the use of the previous IOG tariff code being added to config.yaml.